### PR TITLE
Added bot_mentioned to regular messages 

### DIFF
--- a/src/incoming.js
+++ b/src/incoming.js
@@ -132,6 +132,18 @@ module.exports = (bp, slack) => {
     return /^D/.test(channelId)
   }
 
+  const isBotMentioned = (text) => {
+    let match = [];
+    while (match = mentionRegex.exec(text)) {
+      const mentionedId = match[1];
+      if (mentionedId === slack.getBotId()) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   const router = bp.getRouter('botpress-slack', { 'auth': req => !/\/action-endpoint/i.test(req.originalUrl) })
 
   router.post('/action-endpoint', (req, res) => {
@@ -176,6 +188,7 @@ module.exports = (bp, slack) => {
         type: 'message',
         text: message.text,
         user: user,
+        bot_mentioned: isBotMentioned(message.text),
         ...extractBasics(message)
       })
 


### PR DESCRIPTION
Check for bot mentions in regular message in the case of other middleware also processing the messages.

**Example use case:**
Using Wit.ai, when sending any message that has a certain keyword, wit will fire and the bot will process the message even if the bot wasn't asked to.  

The only way for me to make sure the bot was mentioned was to be able to check for bot_mentioned on a regular message event.  Wit doesn't seem to pick up the second incoming message for bot mentioned that is being sent from this module.