### PR TITLE
Added endpoints as internal functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,29 @@ module.exports = {
         return promise
       })
     })
+
+    // Set up endpoints as internal functions
+    bp.slack['getUserProfile'] = function(id) {
+      return slack.getUserProfile(id);
+    }
+
+    bp.slack['getUsers'] = function() {
+      return slack.getUsers();
+    }
+
+    bp.slack['getChannels'] = function() {
+      return slack.getChannels();
+    }
+
+    bp.slack['getTeam'] = function() {
+      return slack.getTeam();
+    }
+
+    bp.slack['getData'] = function() {
+      return slack.getData();
+    }
+
+
   },
 
   ready: async function(bp, configurator) {


### PR DESCRIPTION
Made it easier for internal logic to access Slack data without having to make http requests.  This avoids auth issues on production for internal logic use and generally makes it easier to use Slack data during operations.